### PR TITLE
fix: inject gson for color serialization on jdk 16+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,13 +10,13 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.36'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 
-	compileOnly 'org.projectlombok:lombok:1.18.4'
-	annotationProcessor 'org.projectlombok:lombok:1.18.4'
+	compileOnly 'org.projectlombok:lombok:1.18.30'
+	annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
 	testImplementation 'junit:junit:4.12'
 	testImplementation 'org.slf4j:slf4j-simple:1.7.12'

--- a/src/main/java/com/bram91/brushmarkers/BrushMarkerMinimapOverlay.java
+++ b/src/main/java/com/bram91/brushmarkers/BrushMarkerMinimapOverlay.java
@@ -57,7 +57,7 @@ class BrushMarkerMinimapOverlay extends Overlay
 		this.config = config;
 		this.plugin = plugin;
 		setPosition(OverlayPosition.DYNAMIC);
-		setPriority(0.0f);
+		setPriority(PRIORITY_LOW);
 		setLayer(OverlayLayer.ABOVE_WIDGETS);
 	}
 

--- a/src/main/java/com/bram91/brushmarkers/BrushMarkerMinimapOverlay.java
+++ b/src/main/java/com/bram91/brushmarkers/BrushMarkerMinimapOverlay.java
@@ -38,7 +38,6 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.OverlayUtil;
 
 class BrushMarkerMinimapOverlay extends Overlay
@@ -58,7 +57,7 @@ class BrushMarkerMinimapOverlay extends Overlay
 		this.config = config;
 		this.plugin = plugin;
 		setPosition(OverlayPosition.DYNAMIC);
-		setPriority(OverlayPriority.LOW);
+		setPriority(0.0f);
 		setLayer(OverlayLayer.ABOVE_WIDGETS);
 	}
 

--- a/src/main/java/com/bram91/brushmarkers/BrushMarkerOverlay.java
+++ b/src/main/java/com/bram91/brushmarkers/BrushMarkerOverlay.java
@@ -44,7 +44,6 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.OverlayUtil;
 
 public class BrushMarkerOverlay extends Overlay
@@ -64,7 +63,7 @@ public class BrushMarkerOverlay extends Overlay
 		this.config = config;
 		this.plugin = plugin;
 		setPosition(OverlayPosition.DYNAMIC);
-		setPriority(OverlayPriority.LOW);
+		setPriority(0.0f);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 	}
 

--- a/src/main/java/com/bram91/brushmarkers/BrushMarkerOverlay.java
+++ b/src/main/java/com/bram91/brushmarkers/BrushMarkerOverlay.java
@@ -63,7 +63,7 @@ public class BrushMarkerOverlay extends Overlay
 		this.config = config;
 		this.plugin = plugin;
 		setPosition(OverlayPosition.DYNAMIC);
-		setPriority(0.0f);
+		setPriority(PRIORITY_LOW);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 	}
 

--- a/src/main/java/com/bram91/brushmarkers/BrushMarkerPlugin.java
+++ b/src/main/java/com/bram91/brushmarkers/BrushMarkerPlugin.java
@@ -44,7 +44,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
-import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ClientTick;
 import net.runelite.api.events.GameStateChanged;
@@ -67,7 +66,8 @@ public class BrushMarkerPlugin extends Plugin implements KeyListener
 	private static final String CONFIG_GROUP = "brushMarkers";
 	private static final String REGION_PREFIX = "region_";
 
-	private static final Gson GSON = new Gson();
+	@Inject
+	private Gson gson;
 
 	@Getter(AccessLevel.PACKAGE)
 	private final List<ColorTileMarker> points = new ArrayList<>();
@@ -111,7 +111,7 @@ public class BrushMarkerPlugin extends Plugin implements KeyListener
 			return;
 		}
 
-		String json = GSON.toJson(points);
+		String json = gson.toJson(points);
 		configManager.setConfiguration(CONFIG_GROUP, REGION_PREFIX + regionId, json);
 	}
 
@@ -124,7 +124,7 @@ public class BrushMarkerPlugin extends Plugin implements KeyListener
 		}
 
 		// CHECKSTYLE:OFF
-		return GSON.fromJson(json, new TypeToken<List<BrushMarkerPoint>>()
+		return gson.fromJson(json, new TypeToken<List<BrushMarkerPoint>>()
 		{
 		}.getType());
 		// CHECKSTYLE:ON
@@ -139,7 +139,7 @@ public class BrushMarkerPlugin extends Plugin implements KeyListener
 		}
 
 		// CHECKSTYLE:OFF
-		return GSON.fromJson(json, new TypeToken<List<BrushMarkerPoint>>()
+		return gson.fromJson(json, new TypeToken<List<BrushMarkerPoint>>()
 		{
 		}.getType());
 		// CHECKSTYLE:ON

--- a/src/main/java/com/bram91/brushmarkers/BrushMarkerWorldmapOverlay.java
+++ b/src/main/java/com/bram91/brushmarkers/BrushMarkerWorldmapOverlay.java
@@ -25,28 +25,20 @@
  */
 package com.bram91.brushmarkers;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.FontMetrics;
-import java.awt.Graphics2D;
-import java.awt.Rectangle;
-import java.awt.geom.Rectangle2D;
-import java.util.Collection;
-import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.Perspective;
 import net.runelite.api.Point;
-import net.runelite.api.RenderOverview;
-import net.runelite.api.coords.LocalPoint;
-import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.widgets.ComponentID;
+import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetID;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.worldmap.WorldMap;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayPriority;
-import net.runelite.client.ui.overlay.OverlayUtil;
+
+import javax.inject.Inject;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
 
 class BrushMarkerWorldmapOverlay extends Overlay
 {
@@ -65,9 +57,9 @@ class BrushMarkerWorldmapOverlay extends Overlay
 		this.config = config;
 		this.plugin = plugin;
 		setPosition(OverlayPosition.DYNAMIC);
-		setPriority(OverlayPriority.HIGH);
+		setPriority(0.0f);
 		setLayer(OverlayLayer.MANUAL);
-		drawAfterInterface(WidgetID.WORLD_MAP_GROUP_ID);
+		drawAfterInterface(InterfaceID.WORLD_MAP);
 	}
 
 	@Override
@@ -85,9 +77,9 @@ class BrushMarkerWorldmapOverlay extends Overlay
 
 	private void drawOnWorldMap(Graphics2D graphics)
 	{
-		RenderOverview ro = client.getRenderOverview();
-		Widget map = client.getWidget(WidgetInfo.WORLD_MAP_VIEW);
-		Float pixelsPerTile = ro.getWorldMapZoom();
+		WorldMap worldMap = client.getWorldMap();
+		Widget map = client.getWidget(ComponentID.WORLD_MAP_MAPVIEW);
+		float pixelsPerTile = worldMap.getWorldMapZoom();
 		if (map == null)
 		{
 			return;
@@ -99,7 +91,7 @@ class BrushMarkerWorldmapOverlay extends Overlay
 		int widthInTiles = (int) Math.ceil(worldMapRect.getWidth() / pixelsPerTile);
 		int heightInTiles = (int) Math.ceil(worldMapRect.getHeight() / pixelsPerTile);
 
-		Point worldMapPosition = ro.getWorldMapPosition();
+		Point worldMapPosition = worldMap.getWorldMapPosition();
 
 		// Offset in tiles from anchor sides
 		int yTileMin = worldMapPosition.getY() - heightInTiles / 2;

--- a/src/main/java/com/bram91/brushmarkers/BrushMarkerWorldmapOverlay.java
+++ b/src/main/java/com/bram91/brushmarkers/BrushMarkerWorldmapOverlay.java
@@ -57,7 +57,7 @@ class BrushMarkerWorldmapOverlay extends Overlay
 		this.config = config;
 		this.plugin = plugin;
 		setPosition(OverlayPosition.DYNAMIC);
-		setPriority(0.0f);
+		setPriority(PRIORITY_LOW);
 		setLayer(OverlayLayer.MANUAL);
 		drawAfterInterface(InterfaceID.WORLD_MAP);
 	}


### PR DESCRIPTION
Closes #2 

Leverages [`ColorTypeAdapter`](https://github.com/runelite/api.runelite.net/blob/master/http-api/src/main/java/net/runelite/http/api/gson/ColorTypeAdapter.java), which is [registered](https://github.com/runelite/api.runelite.net/blob/master/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java#L53) for the injected gson instance

also resolves all-but-one deprecation warning; `OverlayUtil.renderMinimapRect` is remaining, which is addressed by #4
